### PR TITLE
invisible magic error bug thing fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,8 +7,13 @@ arch=$(uname -m)
 goOs="$(tr '[:upper:]' '[:lower:]' <<< ${os})"
 goArch=""
 
+if [ "${goOs}" != "darwin" ] && [ "${goOs}" != "linux" ]; then
+    echo "Unsupported operating system: ${os}"
+    exit 1
+fi
+
 if [ "${arch}" == "x86_64" ]; then
-    goArch="amd64" 
+    goArch="amd64"
 else
     echo "Unsupported arch ${arch}\n"
     exit 1


### PR DESCRIPTION
I tried to install it on cygwin, says "installed dope 0.0.3", then the binary file contains a single line with "Not Found" because the `curl binUrl` is wrong.

If I do:
```
if [ "${goOs}" != "darwin" ] && [ "${goOs}" != "linux" ]; then
    goOs="linux"
fi
```
...instead, it seems to install correctly, but I get `zsh: exec format error: dope` or `bash: /usr/local/bin/dope: cannot execute binary file: Exec format error` when I run it. (I think) This is an architecture problem. My pc doesn't like amd64.